### PR TITLE
add breaking-changes section to changelog

### DIFF
--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -87,24 +87,24 @@ module GitHubChangelogGenerator
     # @return [String] generated log for issues
     def issues_to_log(issues, pull_requests)
       log = ""
-      bugs_a, enhancement_a, issues_a = parse_by_sections(issues, pull_requests)
+      bugs_a, enhancement_a, breaking_a, issues_a = parse_by_sections(issues, pull_requests)
 
+      log += generate_sub_section(breaking_a, options[:breaking_prefix])
       log += generate_sub_section(enhancement_a, options[:enhancement_prefix])
       log += generate_sub_section(bugs_a, options[:bug_prefix])
       log += generate_sub_section(issues_a, options[:issue_prefix])
       log
     end
 
+    # rubocop:disable  Metrics/CyclomaticComplexity
     # This method sort issues by types
     # (bugs, features, or just closed issues) by labels
     #
     # @param [Array] issues
     # @param [Array] pull_requests
-    # @return [Array] tuple of filtered arrays: (Bugs, Enhancements Issues)
+    # @return [Array] tuple of filtered arrays: (Bugs, Enhancements, Breaking stuff,  Issues)
     def parse_by_sections(issues, pull_requests)
-      issues_a = []
-      enhancement_a = []
-      bugs_a = []
+      issues_a = enhancement_a = bugs_a = breaking_a = []
 
       issues.each do |dict|
         added = false
@@ -119,9 +119,15 @@ module GitHubChangelogGenerator
             added = true
             next
           end
+          if options[:breaking_labels].include?(label["name"])
+            breaking_a.push(dict)
+            added = true
+            next
+          end
         end
         issues_a.push(dict) unless added
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       added_pull_requests = []
       pull_requests.each do |pr|
@@ -136,11 +142,16 @@ module GitHubChangelogGenerator
             added_pull_requests.push(pr)
             next
           end
+          if options[:breaking_labels].include?(label["name"])
+            breaking_a.push(pr)
+            added_pull_requests.push(pr)
+            next
+          end
         end
       end
       added_pull_requests.each { |p| pull_requests.delete(p) }
 
-      [bugs_a, enhancement_a, issues_a]
+      [bugs_a, enhancement_a, breaking_a, issues_a]
     end
   end
 end

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -20,6 +20,8 @@ module GitHubChangelogGenerator
       due_tag
       enhancement_labels
       enhancement_prefix
+      breaking_labels
+      breaking_prefix
       exclude_labels
       exclude_tags
       exclude_tags_regex

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -72,6 +72,9 @@ module GitHubChangelogGenerator
         opts.on("--enhancement-label [LABEL]", "Setup custom label for enhancements section. Default is \"**Implemented enhancements:**\"") do |v|
           options[:enhancement_prefix] = v
         end
+        opts.on("--breaking-label [LABEL]", "Setup custom label for the breaking changes section. Default is \"**Breaking changes:**\"") do |v|
+          options[:breaking_prefix] = v
+        end
         opts.on("--issues-label [LABEL]", "Setup custom label for closed-issues section. Default is \"**Closed issues:**\"") do |v|
           options[:issue_prefix] = v
         end
@@ -128,6 +131,9 @@ module GitHubChangelogGenerator
         end
         opts.on("--enhancement-labels  x,y,z", Array, 'Issues with the specified labels will be always added to "Implemented enhancements" section. Default is \'enhancement,Enhancement\'') do |list|
           options[:enhancement_labels] = list
+        end
+        opts.on("--breaking-labels x,y,z", Array, 'Issues with these labels will be added to a new section, called "Breaking Changes". Default is \'backwards-incompatible\'') do |list|
+          options[:breaking_labels] = list
         end
         opts.on("--issue-line-labels x,y,z", Array, 'The specified labels will be shown in brackets next to each matching issue. Use "ALL" to show all labels. Default is [].') do |list|
           options[:issue_line_labels] = list
@@ -209,6 +215,7 @@ module GitHubChangelogGenerator
         compare_link: true,
         enhancement_labels: %w[enhancement Enhancement],
         bug_labels: %w[bug Bug],
+        breaking_labels: %w[backwards-incompatible breaking],
         exclude_labels: %w[duplicate question invalid wontfix Duplicate Question Invalid Wontfix],
         issue_line_labels: [],
         max_issues: nil,
@@ -220,6 +227,7 @@ module GitHubChangelogGenerator
         issue_prefix: "**Closed issues:**",
         bug_prefix: "**Fixed bugs:**",
         enhancement_prefix: "**Implemented enhancements:**",
+        breaking_prefix: "**Breaking changes:**",
         git_remote: "origin",
         http_cache: true
       )

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -67,7 +67,7 @@ module GitHubChangelogGenerator
     end
 
     KNOWN_ARRAY_KEYS = %i[exclude_labels include_labels bug_labels
-                          enhancement_labels issue_line_labels between_tags exclude_tags]
+                          enhancement_labels breaking_labels issue_line_labels between_tags exclude_tags]
     KNOWN_INTEGER_KEYS = [:max_issues]
 
     def convert_value(value, option_name)
@@ -91,6 +91,7 @@ module GitHubChangelogGenerator
       header_label: :header,
       front_matter: :frontmatter,
       pr_label: :merge_prefix,
+      breaking_label: :breaking_prefix,
       issues_wo_labels: :add_issues_wo_labels,
       pr_wo_labels: :add_pr_wo_labels,
       pull_requests: :pulls,


### PR DESCRIPTION
This is a commit I've cherry-picked from github-changelog-generator [PR #530](https://github.com/skywinder/github-changelog-generator/pull/530). We'd really like to be able to add a breaking section to our CHANGELOGs in order to remain consistent with (Make a Changelog)[http://keepachangelog.com/en/1.0.0/].

We're not sure if/when this will get merged and then released upstream, and we're already using this fork for another fid so we'd really appreciate it if we could add this one too!

Let me know if you have any thoughts/concerns or if there's a better way to bring these changes over.